### PR TITLE
chore: lower cmake required version to 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.20)
 project(libmav-example)
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
Ubuntu 22.04 does not yet provide cmake 3.25 via apt. Since this cmake file is very simple, it should be no problem if we lower the required cmake version from 3.25 to 3.20.

Also libmav is currently using cmake 3.20 in its own builds: https://github.com/Auterion/libmav/blob/adf0b41e140ba5b33cd0ad47e0adc32bf7159e76/CMakeLists.txt#L1